### PR TITLE
Remove evaluation_file param

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ from alphaevolve import AlphaEvolve
 
 # Initialize the system
 evolve = AlphaEvolve(
-    initial_program_path="example/sma_momentum.py",
-    evaluation_file="path/to/evaluator.py",
+    initial_program_paths=["example/sma_momentum.py"],
     config_path="example/config.py"
 )
 

--- a/alphaevolve/engine/__init__.py
+++ b/alphaevolve/engine/__init__.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from alphaevolve.store.sqlite import ProgramStore
 from alphaevolve.evolution.controller import Controller
+from alphaevolve.store.sqlite import ProgramStore
 
 __all__ = ["AlphaEvolve", "Strategy"]
 
@@ -19,7 +19,7 @@ class Strategy:
 
     id: str
     code: str
-    metrics: Dict[str, Any]
+    metrics: dict[str, Any]
 
 
 class AlphaEvolve:
@@ -27,15 +27,13 @@ class AlphaEvolve:
 
     def __init__(
         self,
-        initial_program_path: str,
-        evaluation_file: str,
+        initial_program_paths: list[str],
         config_path: str,
         *,
-        store: Optional[ProgramStore] = None,
+        store: ProgramStore | None = None,
     ) -> None:
         # For now we simply ignore the paths but keep them for future use.
-        self.initial_program_path = Path(initial_program_path)
-        self.evaluation_file = Path(evaluation_file)
+        self.initial_program_paths = [Path(p) for p in initial_program_paths]
         self.config_path = Path(config_path)
         self.store = store or ProgramStore()
         self.controller = Controller(self.store)


### PR DESCRIPTION
## Summary
- remove `evaluation_file` from `AlphaEvolve`
- allow list of `initial_program_paths`
- update README example

## Testing
- `ruff check alphaevolve/engine/__init__.py | head -n 20`
- `pytest -q`
