### PR TITLE
Fix typos and improve metrics tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Example environment file for pwb-alphaevolve
 # Copy to `.env` and edit as needed. Values left blank will fall back to
-# defaults specified in `alpha_trader/config.py`.
+# defaults specified in `alphaevolve/config.py`.
 
 # ---------------------------------------------------------------------------
 # OpenAI configuration
@@ -9,7 +9,7 @@
 # Your OpenAI API key (required for live evolution)
 OPENAI_API_KEY=
 
-# Chat model name (default "o3")
+# Chat model name (default "o3-mini")
 OPENAI_MODEL=o3-mini
 
 # Maximum tokens for each response (default 4096)
@@ -19,7 +19,7 @@ MAX_COMPLETION_TOKENS=4096
 # Data & storage
 # ---------------------------------------------------------------------------
 
-# Path to the SQLite database (default \~/.alpha\_trader/programs.db)
+# Path to the SQLite database (default \~/.alphaevolve/programs.db)
 
 SQLITE_DB="~/.alphaevolve/programs.db"
 

--- a/alphaevolve/__init__.py
+++ b/alphaevolve/__init__.py
@@ -1,6 +1,7 @@
 """PWB AlphaEvolve package - discover & evolve trading strategies."""
 
 from .engine import AlphaEvolve, Strategy
+from . import strategies
 
 __all__ = [
     "AlphaEvolve",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,6 +3,7 @@ import importlib
 import pytest
 
 np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
 
 spec = importlib.util.spec_from_file_location(
     "metrics", "alphaevolve/evaluator/metrics.py"
@@ -13,3 +14,15 @@ spec.loader.exec_module(metrics)
 
 def test_sharpe_short_series_returns_zero():
     assert metrics.sharpe(np.array([0.01])) == 0.0
+
+
+def test_max_drawdown():
+    curve = np.array([100, 120, 80, 130], dtype=float)
+    series = pd.Series(curve)
+    assert metrics.max_drawdown(series) == pytest.approx(-1 / 3)
+
+
+def test_cagr_simple_case():
+    curve = pd.Series([1.0, 2.0])
+    result = metrics.cagr(curve, periods_per_year=1)
+    assert result == pytest.approx(np.sqrt(2) - 1)


### PR DESCRIPTION
## Summary
- fix outdated references in `.env.example`
- export `strategies` module so `from alphaevolve import *` works
- expand metrics test coverage for max drawdown and CAGR

## Testing
- `pytest -q`