### PR TITLE
Add genetic prompt evolution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ scripts/           # CLI entry‑points
 
 ---
 
+## Prompt Evolution
+
+The `PromptGenome` dataclass allows the LLM instructions themselves to be
+evolved using a genetic algorithm. Set `ENABLE_PROMPT_EVOLUTION = True` in
+`examples/settings.py` to try this feature. New prompts are mutated, evaluated
+for a few iterations and stored in a separate SQLite database.
+
+---
+
 ## ⚙️  Installation
 
 > **Python ≥ 3.10** required.

--- a/alphaevolve/config.py
+++ b/alphaevolve/config.py
@@ -24,6 +24,10 @@ class Settings(BaseSettings):
 
     # Storage
     sqlite_db: str = Field("~/.alphaevolve/programs.db", env="SQLITE_DB")
+    prompt_population_size: int = Field(50, env="PROMPT_POPULATION_SIZE")
+    prompt_mutation_rate: float = Field(0.3, env="PROMPT_MUTATION_RATE")
+    prompt_iterations: int = Field(5, env="PROMPT_ITERATIONS")
+    prompt_sqlite_db: str = Field("~/.alphaevolve/prompts.db", env="PROMPT_SQLITE_DB")
 
     # ------------------------------------------------------------------
     # Evolutionary parameters

--- a/alphaevolve/default_config.yaml
+++ b/alphaevolve/default_config.yaml
@@ -7,3 +7,6 @@ elite_selection_ratio: 0.1
 exploration_ratio: 0.2
 exploitation_ratio: 0.7
 diversity_metric: edit_distance
+prompt_population_size: 50
+prompt_mutation_rate: 0.3
+prompt_iterations: 5

--- a/alphaevolve/engine.py
+++ b/alphaevolve/engine.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
 """High-level evolution interface."""
+
+from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 from alphaevolve.evolution.controller import Controller
 from alphaevolve.store.sqlite import ProgramStore

--- a/alphaevolve/evaluator/metrics.py
+++ b/alphaevolve/evaluator/metrics.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 def _to_np(arr):
-    if isinstance(arr, (pd.Series, pd.DataFrame)):
+    if isinstance(arr, (pd.Series | pd.DataFrame)):
         arr = arr.values
     return np.asarray(arr, dtype=float)
 

--- a/alphaevolve/evolution/prompt_ga.py
+++ b/alphaevolve/evolution/prompt_ga.py
@@ -1,0 +1,101 @@
+"""Utilities for evolving prompts using a simple genetic algorithm."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from alphaevolve.config import settings
+from alphaevolve.store.sqlite import ProgramStore
+
+if TYPE_CHECKING:
+    from alphaevolve.store.prompt_sqlite import PromptStore
+
+
+@dataclass
+class PromptGenome:
+    system_msg: str
+    user_template: str
+
+
+# --------------------------------------------------------------
+# Genetic operators
+# --------------------------------------------------------------
+
+
+def mutate(prompt: PromptGenome, rate: float | None = None) -> PromptGenome:
+    """Return a slightly mutated copy of the prompt."""
+    rate = rate if rate is not None else settings.prompt_mutation_rate
+    system_msg = prompt.system_msg
+    user_template = prompt.user_template
+
+    if random.random() < rate:
+        parts = system_msg.split()
+        if parts:
+            idx = random.randrange(len(parts))
+            parts[idx] = parts[idx].upper()
+            system_msg = " ".join(parts)
+
+    if random.random() < rate:
+        lines = user_template.splitlines()
+        if lines:
+            idx = random.randrange(len(lines))
+            lines[idx] = lines[idx] + " !"
+            user_template = "\n".join(lines)
+
+    return PromptGenome(system_msg=system_msg, user_template=user_template)
+
+
+def crossover(a: PromptGenome, b: PromptGenome) -> PromptGenome:
+    """Combine two parents into a child prompt."""
+    system_msg = random.choice([a.system_msg, b.system_msg])
+    user_template = random.choice([a.user_template, b.user_template])
+    return PromptGenome(system_msg=system_msg, user_template=user_template)
+
+
+# --------------------------------------------------------------
+# Evaluation loop
+# --------------------------------------------------------------
+
+
+async def evaluate_prompt(
+    prompt: PromptGenome,
+    iterations: int | None = None,
+    *,
+    program_store: ProgramStore | None = None,
+) -> dict[str, Any]:
+    """Evaluate prompt fitness by running a short evolution cycle."""
+    iterations = iterations if iterations is not None else settings.prompt_iterations
+    from alphaevolve.evolution.controller import Controller
+
+    store = program_store or ProgramStore(
+        sqlite_db=":memory:", population_size=10, archive_size=0, num_islands=1
+    )
+    ctrl = Controller(store, initial_program_paths=[], max_concurrency=1)
+    for _ in range(iterations):
+        await ctrl._spawn(None, prompt=prompt)
+        await asyncio.sleep(0.01)
+    top = store.top_k(k=1)
+    if top:
+        return top[0]["metrics"] or {}
+    return {}
+
+
+async def evolve_prompts(store: PromptStore, generations: int = 1) -> None:
+    """High-level GA loop producing new prompts and storing them."""
+    from alphaevolve.llm_engine import prompts
+
+    for _ in range(generations):
+        parents = store.sample_pair()
+        if parents:
+            child = crossover(*parents)
+        else:
+            base = store.sample_prompt()
+            if base is None:
+                base = PromptGenome(prompts.SYSTEM_MSG, prompts.USER_TEMPLATE)
+            child = base
+        child = mutate(child)
+        metrics = await evaluate_prompt(child, iterations=settings.prompt_iterations)
+        store.insert(child, metrics)

--- a/alphaevolve/llm_engine/prompts.py
+++ b/alphaevolve/llm_engine/prompts.py
@@ -15,12 +15,12 @@ return:
     { "code": "<full python code>" }
 """
 
-import textwrap, json
+import textwrap
 from datetime import datetime
-from typing import Dict, Any, List
+from typing import Any
 
+from alphaevolve.evolution.prompt_ga import PromptGenome
 from alphaevolve.store.sqlite import ProgramStore
-
 
 SYSTEM_MSG = """\
 You are Alpha-Trader Evolution-Engine.  You mutate algorithmic-trading
@@ -60,7 +60,7 @@ Task:
 """
 
 
-def _format_metrics(metrics: Dict[str, Any] | None) -> str:
+def _format_metrics(metrics: dict[str, Any] | None) -> str:
     if not metrics:
         return "  (none yet – seed strategy)"
     return "\n".join(f"  {k}: {v:.4g}" for k, v in metrics.items())
@@ -74,21 +74,23 @@ def _format_hof(store: ProgramStore, k: int = 3) -> str:
     for r in rows:
         m = r["metrics"]
         lines.append(
-            f"  Sharpe {m['sharpe']:.3f} | Calmar {m['calmar']:.3f} | "
-            f"CAGR {m['cagr']:.2%}"
+            f"  Sharpe {m['sharpe']:.3f} | Calmar {m['calmar']:.3f} | " f"CAGR {m['cagr']:.2%}"
         )
     return "\n".join(lines)
 
 
-def build(parent: Dict[str, Any] | None, store: ProgramStore) -> List[Dict[str, str]]:
+def build(
+    parent: dict[str, Any] | None,
+    store: ProgramStore,
+    prompt: PromptGenome | None = None,
+) -> list[dict[str, str]]:
     """Return messages list ready for openai.ChatCompletion."""
+    prompt = prompt or PromptGenome(system_msg=SYSTEM_MSG, user_template=USER_TEMPLATE)
     today = datetime.utcnow().date().isoformat()
-    parent_code = textwrap.indent(
-        textwrap.dedent(parent["code"] if parent else ""), "    "
-    )[
+    parent_code = textwrap.indent(textwrap.dedent(parent["code"] if parent else ""), "    ")[
         :4000
     ]  # truncate for token safety
-    user_msg = USER_TEMPLATE.format(
+    user_msg = prompt.user_template.format(
         today=today,
         metrics_tbl=_format_metrics(parent["metrics"] if parent else None),
         parent_code=parent_code or "(root seed – no parent)",
@@ -96,6 +98,6 @@ def build(parent: Dict[str, Any] | None, store: ProgramStore) -> List[Dict[str, 
         k=3,
     )
     return [
-        {"role": "system", "content": SYSTEM_MSG},
+        {"role": "system", "content": prompt.system_msg},
         {"role": "user", "content": user_msg},
     ]

--- a/alphaevolve/store/prompt_sqlite.py
+++ b/alphaevolve/store/prompt_sqlite.py
@@ -1,0 +1,152 @@
+"""SQLite persistence for prompt genomes."""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from alphaevolve.config import settings
+from alphaevolve.evolution.prompt_ga import PromptGenome
+from examples import config as example_config
+
+
+class PromptStore:
+    def __init__(
+        self,
+        db_path: str | os.PathLike = None,
+        *,
+        population_size: int = settings.prompt_population_size,
+        archive_size: int = settings.archive_size,
+    ) -> None:
+        db_path = (
+            Path(db_path)
+            if db_path is not None
+            else Path(settings.sqlite_db).with_name("prompts.db")
+        )
+        db_path = db_path.expanduser()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.population_size = population_size
+        self.archive_size = archive_size
+        self.conn = sqlite3.connect(db_path, check_same_thread=False, isolation_level=None)
+        self.conn.execute(
+            """CREATE TABLE IF NOT EXISTS prompts(
+                 id TEXT PRIMARY KEY,
+                 system_msg TEXT NOT NULL,
+                 user_template TEXT NOT NULL,
+                 metrics TEXT,
+                 created REAL
+               )"""
+        )
+
+    # --------------------------------------------------------------
+    # basic CRUD
+    # --------------------------------------------------------------
+    def insert(
+        self,
+        prompt: PromptGenome,
+        metrics: dict[str, Any] | None = None,
+        prompt_id: str | None = None,
+    ) -> str:
+        prompt_id = prompt_id or str(uuid.uuid4())
+        self.conn.execute(
+            (
+                "INSERT INTO prompts(id, system_msg, user_template, metrics, created)"
+                " VALUES (?,?,?,?,?)"
+            ),
+            (
+                prompt_id,
+                prompt.system_msg,
+                prompt.user_template,
+                json.dumps(metrics) if metrics is not None else None,
+                time.time(),
+            ),
+        )
+        self._prune()
+        return prompt_id
+
+    def update_metrics(self, prompt_id: str, metrics: dict[str, Any]) -> None:
+        self.conn.execute(
+            "UPDATE prompts SET metrics=? WHERE id=?",
+            (json.dumps(metrics), prompt_id),
+        )
+
+    def get(self, prompt_id: str) -> dict[str, Any] | None:
+        cur = self.conn.execute("SELECT * FROM prompts WHERE id=?", (prompt_id,))
+        row = cur.fetchone()
+        return self._row_to_dict(row) if row else None
+
+    def sample_prompt(self) -> PromptGenome | None:
+        cur = self.conn.execute("SELECT * FROM prompts ORDER BY RANDOM() LIMIT 1")
+        row = cur.fetchone()
+        if not row:
+            return None
+        data = self._row_to_dict(row)
+        return PromptGenome(data["system_msg"], data["user_template"])
+
+    def sample_pair(self) -> tuple[PromptGenome, PromptGenome] | None:
+        cur = self.conn.execute("SELECT * FROM prompts ORDER BY RANDOM() LIMIT 2")
+        rows = cur.fetchall()
+        if len(rows) < 2:
+            return None
+        data = [self._row_to_dict(r) for r in rows]
+        return (
+            PromptGenome(data[0]["system_msg"], data[0]["user_template"]),
+            PromptGenome(data[1]["system_msg"], data[1]["user_template"]),
+        )
+
+    def top_k(self, k: int = 5, metric: str = example_config.HOF_METRIC) -> list[dict[str, Any]]:
+        cur = self.conn.execute("SELECT * FROM prompts WHERE metrics IS NOT NULL")
+        rows = [self._row_to_dict(r) for r in cur.fetchall()]
+        rows.sort(key=lambda r: r["metrics"].get(metric, 0.0), reverse=True)
+        return rows[:k]
+
+    # --------------------------------------------------------------
+    # helpers
+    # --------------------------------------------------------------
+    @staticmethod
+    def _row_to_dict(row) -> dict[str, Any]:
+        (
+            prompt_id,
+            system_msg,
+            user_template,
+            metrics_json,
+            created,
+        ) = row
+        return {
+            "id": prompt_id,
+            "system_msg": system_msg,
+            "user_template": user_template,
+            "metrics": json.loads(metrics_json) if metrics_json else None,
+            "created": created,
+        }
+
+    # --------------------------------------------------------------
+    # pruning helpers
+    # --------------------------------------------------------------
+    def _count(self) -> int:
+        cur = self.conn.execute("SELECT COUNT(*) FROM prompts")
+        return cur.fetchone()[0]
+
+    def _prune(self) -> None:
+        count = self._count()
+        if count <= self.population_size:
+            return
+        elite_ids = {r["id"] for r in self.top_k(k=self.archive_size)}
+        if elite_ids:
+            placeholders = ",".join("?" * len(elite_ids))
+            cur = self.conn.execute(
+                f"SELECT id FROM prompts WHERE id NOT IN ({placeholders})",
+                tuple(elite_ids),
+            )
+        else:
+            cur = self.conn.execute("SELECT id FROM prompts")
+        candidates = [row[0] for row in cur.fetchall()]
+        excess = count - self.population_size
+        for pid in random.sample(candidates, min(excess, len(candidates))):
+            self.conn.execute("DELETE FROM prompts WHERE id=?", (pid,))

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -1,0 +1,4 @@
+"""Example runtime settings for optional features."""
+
+# Enable genetic prompt evolution when True.
+ENABLE_PROMPT_EVOLUTION = False

--- a/tests/test_prompt_ga.py
+++ b/tests/test_prompt_ga.py
@@ -1,0 +1,229 @@
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _setup(tmp_path, messages_holder):
+    os.environ.setdefault("OPENAI_API_KEY", "x")
+    installed = []
+
+    yaml_mod = types.ModuleType("yaml")
+    yaml_mod.safe_load = lambda *a, **kw: {}
+    sys.modules["yaml"] = yaml_mod
+    installed.append(("yaml", None))
+    for name in ["pandas", "numpy", "pwb_toolbox", "pwb_toolbox.datasets", "tqdm"]:
+        sys.modules[name] = types.ModuleType(name)
+        installed.append((name, None))
+
+    bt_mod = types.ModuleType("backtrader")
+    bt_mod.Strategy = type("Strategy", (), {})
+    sys.modules["backtrader"] = bt_mod
+    installed.append(("backtrader", None))
+
+    examples_pkg = types.ModuleType("examples")
+    examples_cfg = types.ModuleType("examples.config")
+    examples_cfg.HOF_METRIC = "sharpe"
+    examples_pkg.config = examples_cfg
+    sys.modules["examples"] = examples_pkg
+    sys.modules["examples.config"] = examples_cfg
+    installed.extend([("examples", None), ("examples.config", None)])
+
+    config_mod = types.ModuleType("alphaevolve.config")
+    config_mod.settings = types.SimpleNamespace(
+        sqlite_db=str(tmp_path / "prog.sqlite"),
+        prompt_sqlite_db=str(tmp_path / "prompt.sqlite"),
+        population_size=5,
+        archive_size=0,
+        num_islands=1,
+        elite_selection_ratio=0.1,
+        exploration_ratio=0.2,
+        exploitation_ratio=0.7,
+        prompt_population_size=5,
+        prompt_mutation_rate=1.0,
+        prompt_iterations=1,
+    )
+    sys.modules["alphaevolve.config"] = config_mod
+    installed.append(("alphaevolve.config", None))
+
+    alpha_pkg = types.ModuleType("alphaevolve")
+    alpha_pkg.__path__ = []
+    sys.modules["alphaevolve"] = alpha_pkg
+    installed.append(("alphaevolve", None))
+
+    def load(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        installed.append((name, None))
+        return mod
+
+    patch_mod = load(
+        "alphaevolve.evolution.patching",
+        ROOT / "alphaevolve/evolution/patching.py",
+    )
+    sqlite_mod = load(
+        "alphaevolve.store.sqlite",
+        ROOT / "alphaevolve/store/sqlite.py",
+    )
+    store_pkg = types.ModuleType("alphaevolve.store")
+    store_pkg.__path__ = []
+    store_pkg.sqlite = sqlite_mod
+    sys.modules["alphaevolve.store"] = store_pkg
+    installed.append(("alphaevolve.store", None))
+    ga_mod = load(
+        "alphaevolve.evolution.prompt_ga",
+        ROOT / "alphaevolve/evolution/prompt_ga.py",
+    )
+    prompts_mod = load(
+        "alphaevolve.llm_engine.prompts",
+        ROOT / "alphaevolve/llm_engine/prompts.py",
+    )
+
+    store_mod = load(
+        "alphaevolve.store.prompt_sqlite",
+        ROOT / "alphaevolve/store/prompt_sqlite.py",
+    )
+    load("alphaevolve.store.sqlite", ROOT / "alphaevolve/store/sqlite.py")
+    evaluator_mod = types.ModuleType("alphaevolve.evaluator.backtest")
+
+    async def evaluate(code, *, symbols=None):
+        return {"sharpe": 0.0}
+
+    evaluator_mod.evaluate = evaluate
+    sys.modules["alphaevolve.evaluator.backtest"] = evaluator_mod
+    installed.append(("alphaevolve.evaluator.backtest", None))
+
+    base_file = tmp_path / "base.py"
+    base_file.write_text("class BaseLoggingStrategy:\n    def next(self):\n        pass\n")
+    spec_base = importlib.util.spec_from_file_location("alphaevolve.strategies.base", base_file)
+    base_mod = importlib.util.module_from_spec(spec_base)
+    spec_base.loader.exec_module(base_mod)
+    sys.modules["alphaevolve.strategies.base"] = base_mod
+    installed.append(("alphaevolve.strategies.base", None))
+
+    openai_client = types.ModuleType("alphaevolve.llm_engine.openai_client")
+
+    async def chat(messages, **kw):
+        messages_holder.append(messages)
+        return types.SimpleNamespace(content='{"code": "pass"}')
+
+    openai_client.chat = chat
+    llm_pkg = types.ModuleType("alphaevolve.llm_engine")
+    llm_pkg.__path__ = []
+    llm_pkg.prompts = prompts_mod
+    llm_pkg.openai_client = openai_client
+    sys.modules["alphaevolve.llm_engine"] = llm_pkg
+    installed.append(("alphaevolve.llm_engine", None))
+
+    controller_mod = load(
+        "alphaevolve.evolution.controller",
+        ROOT / "alphaevolve/evolution/controller.py",
+    )
+
+    store_pkg.prompt_sqlite = store_mod
+
+    evolution_pkg = types.ModuleType("alphaevolve.evolution")
+    evolution_pkg.__path__ = []
+    evolution_pkg.patching = patch_mod
+    evolution_pkg.prompt_ga = ga_mod
+    sys.modules["alphaevolve.evolution"] = evolution_pkg
+    installed.append(("alphaevolve.evolution", None))
+
+    alpha_pkg = types.ModuleType("alphaevolve")
+    alpha_pkg.__path__ = []
+    alpha_pkg.llm_engine = llm_pkg
+    alpha_pkg.store = store_pkg
+    alpha_pkg.evolution = evolution_pkg
+    alpha_pkg.config = config_mod
+    alpha_pkg.evaluator = evaluator_mod
+    sys.modules["alphaevolve"] = alpha_pkg
+    installed.append(("alphaevolve", None))
+
+    return (
+        ga_mod.PromptGenome,
+        ga_mod.mutate,
+        store_mod.PromptStore,
+        controller_mod.Controller,
+        installed,
+    )
+
+
+def _cleanup(installed):
+    for name, prev in installed:
+        if prev is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = prev
+
+
+async def _run_spawn(ctrl, prompt):
+    await ctrl._spawn(None, prompt=prompt)
+
+
+def test_controller_uses_custom_prompt(tmp_path):
+    messages = []
+    (
+        PromptGenome,
+        mutate,
+        PromptStore,
+        Controller,
+        installed,
+    ) = _setup(tmp_path, messages)
+    try:
+        prog_store = importlib.import_module("alphaevolve.store.sqlite").ProgramStore
+        ctrl = Controller(
+            prog_store(
+                tmp_path / "db.sqlite",
+                population_size=2,
+                archive_size=0,
+                num_islands=1,
+            ),
+            max_concurrency=1,
+        )
+        prompt = PromptGenome("SYS", "USER: {today}")
+        asyncio.run(_run_spawn(ctrl, prompt))
+        assert messages[0][0]["content"] == "SYS"
+    finally:
+        _cleanup(installed)
+
+
+def test_prompt_store_insert_get(tmp_path):
+    messages = []
+    (
+        PromptGenome,
+        mutate,
+        PromptStore,
+        Controller,
+        installed,
+    ) = _setup(tmp_path, messages)
+    try:
+        store = PromptStore(tmp_path / "p.sqlite", population_size=2, archive_size=0)
+        prompt = PromptGenome("a", "b")
+        pid = store.insert(prompt, metrics={"sharpe": 1.0})
+        row = store.get(pid)
+        assert row["metrics"]["sharpe"] == 1.0
+    finally:
+        _cleanup(installed)
+
+
+def test_mutate_changes_prompt(tmp_path):
+    messages = []
+    (
+        PromptGenome,
+        mutate,
+        PromptStore,
+        Controller,
+        installed,
+    ) = _setup(tmp_path, messages)
+    try:
+        p = PromptGenome("hello world", "line")
+        m = mutate(p, rate=1.0)
+        assert m.system_msg != p.system_msg or m.user_template != p.user_template
+    finally:
+        _cleanup(installed)


### PR DESCRIPTION
## Summary
- add `PromptGenome` dataclass and GA utilities
- extend controller and prompts to support custom prompts
- add `PromptStore` persistence
- expose prompt-evolution settings and example toggle
- document feature in README
- include tests for prompt GA

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cac57830483299f011a6a58923920