### PR TITLE
Add LLM backend abstraction

### DIFF
--- a/alphaevolve/config.py
+++ b/alphaevolve/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     openai_api_key: str = Field(..., env="OPENAI_API_KEY")
     openai_model: str = Field("o3-mini", env="OPENAI_MODEL")
     max_completion_tokens: int = Field(4096, env="MAX_COMPLETION_TOKENS")
+    llm_backend: str = Field("openai", env="LLM_BACKEND")
 
     # Storage
     sqlite_db: str = Field("~/.alphaevolve/programs.db", env="SQLITE_DB")

--- a/alphaevolve/default_config.yaml
+++ b/alphaevolve/default_config.yaml
@@ -10,3 +10,4 @@ diversity_metric: edit_distance
 prompt_population_size: 50
 prompt_mutation_rate: 0.3
 prompt_iterations: 5
+llm_backend: openai

--- a/alphaevolve/evolution/controller.py
+++ b/alphaevolve/evolution/controller.py
@@ -18,15 +18,14 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from alphaevolve.config import settings
-from alphaevolve.llm_engine import prompts, openai_client
-from examples import config as example_config
-from alphaevolve.evolution.patching import apply_patch
 from alphaevolve.evaluator.backtest import evaluate
 from alphaevolve.evolution.patching import apply_patch
 from alphaevolve.evolution.prompt_ga import PromptGenome
-from alphaevolve.llm_engine import openai_client, prompts
+from alphaevolve.llm_engine import client as llm_client
+from alphaevolve.llm_engine import prompts
 from alphaevolve.store.sqlite import ProgramStore
 from alphaevolve.strategies.base import BaseLoggingStrategy
+from examples import config as example_config
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +106,7 @@ class Controller:
             # 2) Build prompt & call OpenAI
             messages = prompts.build(parent, self.store, metric=self.metric, prompt=prompt)
             try:
-                msg = await openai_client.chat(messages)
+                msg = await llm_client.chat(messages)
             except Exception as e:
                 logger.error(f"OpenAI call failed: {e}")
                 return
@@ -139,9 +138,7 @@ class Controller:
                 parent_id=parent["id"],
                 island=parent.get("island", 0),
             )
-            logger.info(
-                "Child stored (%s %.2f)", self.metric, kpis.get(self.metric, 0)
-            )
+            logger.info("Child stored (%s %.2f)", self.metric, kpis.get(self.metric, 0))
 
     # ------------------------------------------------------------------
     # public API

--- a/alphaevolve/llm_engine/__init__.py
+++ b/alphaevolve/llm_engine/__init__.py
@@ -1,0 +1,26 @@
+"""LLM engine selection wrapper."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+from alphaevolve.config import settings
+
+from . import prompts  # re-export for convenience
+from .base_client import LLMClient
+
+
+def _load_client() -> LLMClient:
+    backend = settings.llm_backend.lower()
+    if backend == "openai":
+        module = import_module("alphaevolve.llm_engine.openai_client")
+        return module.OpenAIClient()  # type: ignore[no-any-return]
+    if backend == "local":
+        module = import_module("alphaevolve.llm_engine.local_client")
+        return module.LocalClient()  # type: ignore[no-any-return]
+    raise ValueError(f"Unknown LLM backend: {settings.llm_backend}")
+
+
+client: LLMClient = _load_client()
+
+__all__ = ["prompts", "client", "LLMClient"]

--- a/alphaevolve/llm_engine/base_client.py
+++ b/alphaevolve/llm_engine/base_client.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class LLMClient(ABC):
+    """Abstract base class for all LLM backends."""
+
+    @abstractmethod
+    async def chat(self, messages: list[dict[str, str]], **kw) -> Any:
+        """Return the LLM response for a list of chat ``messages``."""
+        raise NotImplementedError

--- a/alphaevolve/llm_engine/local_client.py
+++ b/alphaevolve/llm_engine/local_client.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .base_client import LLMClient
+
+
+class LocalClient(LLMClient):
+    """Placeholder local LLM client. Currently unimplemented."""
+
+    async def chat(self, messages: list[dict[str, str]], **kw) -> Any:
+        raise NotImplementedError("Local LLM backend not implemented")

--- a/alphaevolve/llm_engine/openai_client.py
+++ b/alphaevolve/llm_engine/openai_client.py
@@ -1,33 +1,44 @@
-"""Thin async wrapper around the OpenAI Chat Completions API.
+"""Thin async wrapper around the OpenAI Chat Completions API."""
 
-* Transparent exponential back‑off with `backoff` package
-* Enforces structured‑output (`{"type": "json_object"}`)
-* Centralised settings via `alphaevolve.config.settings`
-"""
+from __future__ import annotations
 
-import openai
+from typing import Any
+
 import backoff
-from typing import List, Dict, Any
+import openai
 
 from alphaevolve.config import settings
 
-# Configure global client key
-openai.api_type = "openai"
-openai.api_key = settings.openai_api_key
-async_client = openai.AsyncOpenAI(api_key=settings.openai_api_key)
+from .base_client import LLMClient
 
 
-@backoff.on_exception(backoff.expo, openai.OpenAIError, max_tries=5, jitter=backoff.full_jitter)
-async def chat(messages: List[Dict[str, str]], **kw) -> Any:
-    """Call OpenAI chat completion returning the `message` object of first choice."""
-    # ensure response_format enforced
-    response_format = {"type": "json_object"}
-    params = dict(
-        model=settings.openai_model,
-        messages=messages,
-        max_completion_tokens=settings.max_completion_tokens,
-        response_format=response_format,
-    )
-    params.update(kw)
-    completion = await async_client.chat.completions.create(**params)
-    return completion.choices[0].message
+class OpenAIClient(LLMClient):
+    """Concrete :class:`LLMClient` using OpenAI's Chat Completions API."""
+
+    def __init__(self) -> None:
+        openai.api_type = "openai"
+        openai.api_key = settings.openai_api_key
+        self._client = openai.AsyncOpenAI(api_key=settings.openai_api_key)
+
+    @backoff.on_exception(backoff.expo, openai.OpenAIError, max_tries=5, jitter=backoff.full_jitter)
+    async def chat(self, messages: list[dict[str, str]], **kw) -> Any:
+        """Call OpenAI chat completion returning the ``message`` of the first choice."""
+        response_format = {"type": "json_object"}
+        params = {
+            "model": settings.openai_model,
+            "messages": messages,
+            "max_completion_tokens": settings.max_completion_tokens,
+            "response_format": response_format,
+        }
+        params.update(kw)
+        completion = await self._client.chat.completions.create(**params)
+        return completion.choices[0].message
+
+
+# Backwards compatible helper
+client = OpenAIClient()
+
+
+async def chat(messages: list[dict[str, str]], **kw) -> Any:  # pragma: no cover - thin wrapper
+    """Module level helper calling :class:`OpenAIClient.chat`."""
+    return await client.chat(messages, **kw)

--- a/alphaevolve/llm_engine/prompts.py
+++ b/alphaevolve/llm_engine/prompts.py
@@ -85,7 +85,7 @@ def build(
     store: ProgramStore,
     metric: str = example_config.HOF_METRIC,
     prompt: PromptGenome | None = None,
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Return messages list ready for openai.ChatCompletion."""
     prompt = prompt or PromptGenome(system_msg=SYSTEM_MSG, user_template=USER_TEMPLATE)
     today = datetime.utcnow().date().isoformat()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -55,6 +55,7 @@ def _setup_controller(tmp_path, diff_content, metrics, population_size=5):
         elite_selection_ratio=0.1,
         exploration_ratio=0.2,
         exploitation_ratio=0.7,
+        llm_backend="openai",
     )
     _install("alphaevolve.config", config_mod, installed)
 
@@ -85,13 +86,12 @@ def _setup_controller(tmp_path, diff_content, metrics, population_size=5):
     )
 
     # stubs that depend on runtime values
-    openai_client = types.ModuleType("alphaevolve.llm_engine.openai_client")
+    client = types.SimpleNamespace()
 
     async def chat(messages, **kw):
         return types.SimpleNamespace(content=diff_content)
 
-    openai_client.chat = chat
-    _install("alphaevolve.llm_engine.openai_client", openai_client, installed)
+    client.chat = chat
 
     evaluator_mod = types.ModuleType("alphaevolve.evaluator.backtest")
     # ensure metrics include keys used by prompts._format_hof
@@ -115,7 +115,7 @@ def _setup_controller(tmp_path, diff_content, metrics, population_size=5):
     llm_pkg = types.ModuleType("alphaevolve.llm_engine")
     llm_pkg.__path__ = []
     llm_pkg.prompts = prompts_mod
-    llm_pkg.openai_client = openai_client
+    llm_pkg.client = client
     _install("alphaevolve.llm_engine", llm_pkg, installed)
 
     store_pkg = types.ModuleType("alphaevolve.store")

--- a/tests/test_prompt_ga.py
+++ b/tests/test_prompt_ga.py
@@ -46,6 +46,7 @@ def _setup(tmp_path, messages_holder):
         prompt_population_size=5,
         prompt_mutation_rate=1.0,
         prompt_iterations=1,
+        llm_backend="openai",
     )
     sys.modules["alphaevolve.config"] = config_mod
     installed.append(("alphaevolve.config", None))
@@ -107,17 +108,17 @@ def _setup(tmp_path, messages_holder):
     sys.modules["alphaevolve.strategies.base"] = base_mod
     installed.append(("alphaevolve.strategies.base", None))
 
-    openai_client = types.ModuleType("alphaevolve.llm_engine.openai_client")
+    client = types.SimpleNamespace()
 
     async def chat(messages, **kw):
         messages_holder.append(messages)
         return types.SimpleNamespace(content='{"code": "pass"}')
 
-    openai_client.chat = chat
+    client.chat = chat
     llm_pkg = types.ModuleType("alphaevolve.llm_engine")
     llm_pkg.__path__ = []
     llm_pkg.prompts = prompts_mod
-    llm_pkg.openai_client = openai_client
+    llm_pkg.client = client
     sys.modules["alphaevolve.llm_engine"] = llm_pkg
     installed.append(("alphaevolve.llm_engine", None))
 


### PR DESCRIPTION
## Summary
- introduce `LLMClient` abstract base class
- implement `OpenAIClient` conforming to interface
- provide runtime backend selection in `llm_engine` package
- add `llm_backend` setting in configuration
- update controller to use generic client
- adjust tests for new interface

## Testing
- `ruff check alphaevolve/llm_engine/base_client.py alphaevolve/llm_engine/openai_client.py alphaevolve/llm_engine/__init__.py alphaevolve/llm_engine/local_client.py alphaevolve/evolution/controller.py alphaevolve/config.py alphaevolve/llm_engine/prompts.py tests/test_controller.py tests/test_prompt_ga.py`
- `black alphaevolve/llm_engine/base_client.py alphaevolve/llm_engine/openai_client.py alphaevolve/llm_engine/__init__.py alphaevolve/llm_engine/local_client.py alphaevolve/evolution/controller.py alphaevolve/config.py tests/test_controller.py tests/test_prompt_ga.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb86399d88329ae87ad3fe7c7260e