### PR TITLE
Add local LLM client

### DIFF
--- a/alphaevolve/config.py
+++ b/alphaevolve/config.py
@@ -5,6 +5,9 @@ Environment variables (defaults in brackets):
 OPENAI_API_KEY    – Required for evolution step (no default)
 OPENAI_MODEL      – Chat model name ["o3-mini"]
 MAX_COMPLETION_TOKENS        – Token cap for LLM replies [4096]
+LOCAL_MODEL_NAME  – HuggingFace model name [None]
+LOCAL_MODEL_PATH  – Path to local model [None]
+LOCAL_SERVER_URL  – OpenAI-compatible server base URL [None]
 
 SQLITE_DB         – Path to SQLite file ["~/.alphaevolve/programs.db"]
 """
@@ -22,6 +25,10 @@ class Settings(BaseSettings):
     openai_model: str = Field("o3-mini", env="OPENAI_MODEL")
     max_completion_tokens: int = Field(4096, env="MAX_COMPLETION_TOKENS")
     llm_backend: str = Field("openai", env="LLM_BACKEND")
+    # Local backend options
+    local_model_name: str | None = Field(None, env="LOCAL_MODEL_NAME")
+    local_model_path: str | None = Field(None, env="LOCAL_MODEL_PATH")
+    local_server_url: str | None = Field(None, env="LOCAL_SERVER_URL")
 
     # Storage
     sqlite_db: str = Field("~/.alphaevolve/programs.db", env="SQLITE_DB")

--- a/alphaevolve/default_config.yaml
+++ b/alphaevolve/default_config.yaml
@@ -11,3 +11,6 @@ prompt_population_size: 50
 prompt_mutation_rate: 0.3
 prompt_iterations: 5
 llm_backend: openai
+local_model_name:
+local_model_path:
+local_server_url:

--- a/alphaevolve/llm_engine/local_client.py
+++ b/alphaevolve/llm_engine/local_client.py
@@ -1,12 +1,64 @@
+"""Async local LLM client used when ``LLM_BACKEND`` is ``local``.
+
+This implementation supports two operating modes:
+
+1. If ``LOCAL_SERVER_URL`` is configured, requests are forwarded to an
+   OpenAI-compatible server using ``openai.AsyncOpenAI``.
+2. Otherwise a local HuggingFace model is loaded via ``transformers.pipeline``
+   for text generation.
+
+Both modes return an object with a ``content`` attribute matching the
+:class:`openai.types.chat.chat_completion_message.ChatCompletionMessage`
+interface used by :mod:`openai_client`.
+"""
+
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
 from typing import Any
+
+from alphaevolve.config import settings
 
 from .base_client import LLMClient
 
 
 class LocalClient(LLMClient):
-    """Placeholder local LLM client. Currently unimplemented."""
+    """Concrete :class:`LLMClient` for local models."""
+
+    def __init__(self) -> None:
+        self.server_url = settings.local_server_url
+        self.model_name = settings.local_model_name
+        self.model_path = settings.local_model_path
+        if self.server_url:
+            import openai
+
+            # API key is ignored by many local servers but required by the client
+            self._client = openai.AsyncOpenAI(base_url=self.server_url, api_key="x")
+        else:
+            from transformers import pipeline
+
+            model = self.model_path or self.model_name or "gpt2"
+            self._pipeline = pipeline("text-generation", model=model)
 
     async def chat(self, messages: list[dict[str, str]], **kw) -> Any:
-        raise NotImplementedError("Local LLM backend not implemented")
+        """Return the LLM response for a list of ``messages``."""
+        if self.server_url:
+            params = {
+                "model": self.model_name,
+                "messages": messages,
+                "max_tokens": settings.max_completion_tokens,
+            }
+            params.update(kw)
+            completion = await self._client.chat.completions.create(**params)
+            return completion.choices[0].message
+
+        prompt = "\n".join(m["content"] for m in messages)
+        max_tokens = kw.get("max_new_tokens", settings.max_completion_tokens)
+
+        def _run() -> str:
+            result = self._pipeline(prompt, max_new_tokens=max_tokens)
+            return result[0]["generated_text"]
+
+        generated = await asyncio.to_thread(_run)
+        return SimpleNamespace(content=generated)


### PR DESCRIPTION
## Summary
- implement `LocalClient` that loads a local HuggingFace model or forwards requests to an OpenAI compatible server
- expose configuration options for the local backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cba7ce64c83299a2bab6605f38b64