### PR TITLE
Improve evolution prompts and selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ python scripts/run_example.py --experiment my_exp
 | Data       | Zero‑setup loader for any Papers‑With‑Backtest dataset (`pwb_toolbox`) + caching to Feather |
 | Strategies | Seed templates with **EVOLVE‑BLOCK** markers that the LLM mutates                           |
 | Evaluator  | Deterministic Backtrader walk‑forward, JSON KPIs (Sharpe, CAGR, Calmar, DD)                 |
-| LLM Engine | OpenAI o3 structured‑output chat → JSON diff/patch system                                   |
-| Evolution  | Async controller, SQLite hall‑of‑fame, optional MAP‑Elites niches                           |
+| LLM Engine | OpenAI o3 structured‑output chat → JSON diff/patch system; prompts push each child to beat its parent |
+| Evolution  | Async controller stores a child only when it improves the chosen metric; SQLite hall‑of‑fame, optional MAP‑Elites niches |
 | Dashboard  | (optional) Streamlit live view of metrics & equity curves                                   |
 
 ---

--- a/alphaevolve/evolution/controller.py
+++ b/alphaevolve/evolution/controller.py
@@ -134,14 +134,26 @@ class Controller:
                 logger.error(f"Evaluation failed: {e}")
                 return
 
-            # 5) Persist
-            self.store.insert(
-                child_code,
-                kpis,
-                parent_id=parent["id"],
-                island=parent.get("island", 0),
-            )
-            logger.info("Child stored (%s %.2f)", self.metric, kpis.get(self.metric, 0))
+            # 5) Persist if improved
+            parent_metrics = parent.get("metrics") or {}
+            parent_val = parent_metrics.get(self.metric)
+            child_val = kpis.get(self.metric)
+
+            if child_val is None or parent_val is None or child_val > parent_val:
+                self.store.insert(
+                    child_code,
+                    kpis,
+                    parent_id=parent["id"],
+                    island=parent.get("island", 0),
+                )
+                logger.info("Child stored (%s %.2f)", self.metric, kpis.get(self.metric, 0))
+            else:
+                logger.info(
+                    "Discarded child (%s %.2f <= %.2f)",
+                    self.metric,
+                    child_val,
+                    parent_val,
+                )
 
     # ------------------------------------------------------------------
     # public API

--- a/alphaevolve/llm_engine/prompts.py
+++ b/alphaevolve/llm_engine/prompts.py
@@ -25,7 +25,8 @@ from examples import config as example_config
 
 SYSTEM_MSG = """\
 You are Alpha-Trader Evolution-Engine.  You mutate algorithmic-trading
-strategies written for Backtrader.  All editable regions are delimited
+strategies written for Backtrader.  Each new iteration should attempt
+to outperform its parent based on risk-adjusted metrics.  All editable regions are delimited
 like this:
 
     # === EVOLVE-BLOCK: <block_name> =================================

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -211,3 +211,27 @@ def test_controller_respects_population_limit(tmp_path):
         assert store._count() <= 2
     finally:
         _cleanup(installed)
+
+
+def test_controller_discards_unimproved_child(tmp_path):
+    diff = '{"blocks": {"logic": "b = 2"}}'
+    metrics = {"sharpe": 1.0}
+    ctrl, store, installed = _setup_controller(tmp_path, diff, metrics)
+    try:
+        # first spawn inserts child with sharpe 1.0
+        asyncio.run(_run_spawn(ctrl))
+        child_id = store.top_k(k=1)[0]["id"]
+
+        # make evaluator return worse metrics
+        async def evaluate(_code, *, symbols=None):
+            return {"sharpe": 0.5, "calmar": 0.0, "cagr": 0.0}
+
+        sys.modules["alphaevolve.evaluator.backtest"].evaluate = evaluate
+
+        # spawn from the existing child
+        asyncio.run(ctrl._spawn(child_id))
+
+        # count should remain 2 since new child discarded
+        assert store._count() == 2
+    finally:
+        _cleanup(installed)


### PR DESCRIPTION
## Summary
- enhance system prompt to explicitly state that each child should beat its parent
- save new strategies only when the chosen metric improves on the parent
- document the new behaviour in the README
- add regression test for discarding unimproved children

## Testing
- `ruff check alphaevolve/evolution/controller.py alphaevolve/llm_engine/prompts.py tests/test_controller.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff9537a788329b69922d7dc19f65b