### PR TITLE
Add references for seed strategies and datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ $ export OPENAI_API_KEY=sk-...
 $ export HF_ACCESS_TOKEN=hf_
 ```
 
+Seed strategy code can be found on [paperswithbacktest.com](https://paperswithbacktest.com/) and the required data for the backtest can be obtained from [paperswithbacktest.com/datasets](https://paperswithbacktest.com/datasets).
+
 Launch and monitor an experiment entirely from the GUI:
 
 ```bash


### PR DESCRIPTION
## Summary
- mention that seed strategy code is hosted on paperswithbacktest.com
- add link to datasets for backtesting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ffc6b2b248329937bfc7a76b6e2a2